### PR TITLE
Fix null frequency notes in comparator

### DIFF
--- a/base/src/main/java/de/schliweb/bluesharpbendingapp/model/harmonica/ChordAndDetectionResultComparator.java
+++ b/base/src/main/java/de/schliweb/bluesharpbendingapp/model/harmonica/ChordAndDetectionResultComparator.java
@@ -87,7 +87,10 @@ public class ChordAndDetectionResultComparator implements Comparator<Object> {
             double f2 = copyFrequency2.get(i);
             String n1 = NoteLookup.getNoteName(f1);
             String n2 = NoteLookup.getNoteName(f2);
-            assert n1 != null;
+
+            if (n1 == null || n2 == null) {
+                return false;
+            }
             if (!n1.equals(n2)) {
                 return false;
             }


### PR DESCRIPTION
## Summary
- fix potential NPE in `ChordAndDetectionResultComparator` when note lookup fails

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842ee35c5388329ab91d63afedc3e1b